### PR TITLE
Issue#89: 'Recommendations' tab title is wrong #89

### DIFF
--- a/VAKidney/app/src/main/res/layout/activity_main.xml
+++ b/VAKidney/app/src/main/res/layout/activity_main.xml
@@ -203,7 +203,7 @@
                 android:layout_marginBottom="4dp"
                 android:gravity="center"
                 android:lines="1"
-                android:text="Recommendations"
+                android:text="Nutrition and Drug Interaction"
                 android:textColor="@color/brandBlueLight"
                 android:textSize="11sp" />
         </LinearLayout>


### PR DESCRIPTION

Adjusted the text 'Recommendations' to 'Nutrition and Drug Interaction' to be same as
iPhone App (Comparison) 